### PR TITLE
Do no delete idb on SW installation

### DIFF
--- a/app/templates/sw.js
+++ b/app/templates/sw.js
@@ -223,7 +223,6 @@ function install(){
 self.addEventListener('install', function(event){
   // console.log("SW installed -from sw.js");
   setTimeout(install, 800);
-  indexedDB.deleteDatabase("swdb");
 });
 
 self.addEventListener('message', function(e){


### PR DESCRIPTION
This ensures that idb data is stored also on reinstallation of the SW
(dom poisoning)

Fixes #3 